### PR TITLE
Fix of: (Incorrect field name Player -> player)

### DIFF
--- a/CustomCobbleGen-JetsMinions/src/main/java/me/phil14052/CustomCobbleGen/JetsMinions/events/MinionEvents.java
+++ b/CustomCobbleGen-JetsMinions/src/main/java/me/phil14052/CustomCobbleGen/JetsMinions/events/MinionEvents.java
@@ -2,25 +2,19 @@ package me.phil14052.CustomCobbleGen.JetsMinions.events;
 
 import me.jet315.minions.events.MinerBlockBreakEvent;
 import me.phil14052.CustomCobbleGen.API.CustomCobbleGenAPI;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-
-import java.lang.reflect.Field;
 
 public class MinionEvents implements Listener {
 
     @EventHandler
     public void onMinionBreak(MinerBlockBreakEvent e) {
         Location loc = e.getBlock().getLocation();
-        try {
-            Field f = e.getMinion().getClass().getDeclaredField("player");
-            f.setAccessible(true);
-            Player p = (Player) f.get(e.getMinion());
-            CustomCobbleGenAPI.getAPI().registerBlockBreak(p, loc);
-        } catch (NoSuchFieldException | IllegalAccessException noSuchFieldException) {
-            noSuchFieldException.printStackTrace();
-        }
+        Player player=Bukkit.getPlayer(e.getMinion().getPlayerUUID());
+        if(player==null)return;
+        CustomCobbleGenAPI.getAPI().registerBlockBreak(player,loc);
     }
 }

--- a/CustomCobbleGen-JetsMinions/src/main/java/me/phil14052/CustomCobbleGen/JetsMinions/events/MinionEvents.java
+++ b/CustomCobbleGen-JetsMinions/src/main/java/me/phil14052/CustomCobbleGen/JetsMinions/events/MinionEvents.java
@@ -15,7 +15,7 @@ public class MinionEvents implements Listener {
     public void onMinionBreak(MinerBlockBreakEvent e) {
         Location loc = e.getBlock().getLocation();
         try {
-            Field f = e.getMinion().getClass().getDeclaredField("Player");
+            Field f = e.getMinion().getClass().getDeclaredField("player");
             f.setAccessible(true);
             Player p = (Player) f.get(e.getMinion());
             CustomCobbleGenAPI.getAPI().registerBlockBreak(p, loc);


### PR DESCRIPTION
[17:39:47 ERROR]: Could not pass event MinerBlockBreakEvent to CustomCobbleGen v1.4.5
       java.lang.IllegalAccessError: class me.phil14052.CustomCobbleGen.Events.MinionEvents tried to access protected method 'org.bukkit.entity.Player me.jet315.minions.minions.Minion.getPlayer()' (me.phil14052.CustomCobbleGen.Events.MinionEvents is in unnamed module of loader 'CustomCobbleGen-1.4.5.jar' @9230ad5; me.jet315.minions.minions.Minion is in unnamed module of loader 'JetsMinions-7.6.17.jar' @2eb204c2)
               at me.phil14052.CustomCobbleGen.Events.MinionEvents.onMinionBreak(MinionEvents.java:25) ~[CustomCobbleGen-1.4.5.jar:?]
               at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor1185.execute(Unknown Source) ~[?:?]
               at org.bukkit.plugin.EventExecutor$2.execute(EventExecutor.java:77) ~[purpur-api-1.19.2-R0.1-SNAPSHOT.jar:?]
               at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[purpur-api-1.19.2-R0.1-SNAPSHOT.jar:git-Purpur-1858]
               at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[purpur-api-1.19.2-R0.1-SNAPSHOT.jar:?]
               at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:678) ~[purpur-api-1.19.2-R0.1-SNAPSHOT.jar:?]
               at me.jet315.minions.minions.types.MinerMinion.performAction(MinerMinion.java:165) ~[JetsMinions-7.6.17.jar:?]
               at me.jet315.minions.manager.MinionTask$1.run(MinionTask.java:39) ~[JetsMinions-7.6.17.jar:?]
               at org.bukkit.craftbukkit.v1_19_R1.scheduler.CraftTask.run(CraftTask.java:101) ~[purpur-1.19.2.jar:git-Purpur-1858]
               at org.bukkit.craftbukkit.v1_19_R1.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:483) ~[purpur-1.19.2.jar:git-Purpur-1858]
               at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1500) ~[purpur-1.19.2.jar:git-Purpur-1858]
               at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:486) ~[purpur-1.19.2.jar:git-Purpur-1858]
               at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1424) ~[purpur-1.19.2.jar:git-Purpur-1858]
               at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1194) ~[purpur-1.19.2.jar:git-Purpur-1858]
               at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:310) ~[purpur-1.19.2.jar:git-Purpur-1858]
               at java.lang.Thread.run(Thread.java:833) ~[?:?]

Signed-off-by: petulikan1 <petulikan@gmail.com>